### PR TITLE
One example of how to minify build

### DIFF
--- a/{{cookiecutter.extension_name}}/package.json
+++ b/{{cookiecutter.extension_name}}/package.json
@@ -14,11 +14,11 @@
     "lib/*.d.ts",
     "lib/*.js.map",
     "lib/*.js",
-    "style/*.css",
-    "style/*.ttf",
-    "style/*.eot",
-    "style/*.woff",
-    "style/*.woff2"
+    "static/*.css",
+    "static/*.ttf",
+    "static/*.eot",
+    "static/*.woff",
+    "static/*.woff2"
   ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -26,9 +26,10 @@
     "lib": "lib/"
   },
   "scripts": {
-    "build": "tsc -b",
+    "build": "tsc -b && webpack",
+    "build:src": "tsc -b",
     "build:webpack": "webpack",
-    "clean": "rimraf lib",
+    "clean": "rimraf lib && rimraf static",
     "prepare": "npm run clean && npm run build",
     "watch": "tsc -w",
     "watch:webpack": "webpack --watch"
@@ -56,8 +57,8 @@
   },
   "jupyterlab": {
     "extension": true,
-    "themeDir": "style",
-    "themePath": "style/index.css"
+    "themeDir": "static",
+    "themePath": "static/index.css"
   },
   "homepage": "{{ cookiecutter.url }}",
 {%- if "http://github.com/" in cookiecutter.url or "https://github.com/" in cookiecutter.url %}


### PR DESCRIPTION
All recent versions of the internal themes use a bunch of minify stuff to pack their css and image files up more nicely. It needs to be decided if some version of the minify stuff should also be in this theme template.

The minify setup in this PR resembles that being used in [@jupyterlab/theme-light-extension/webpack.conf.js](https://github.com/jupyterlab/jupyterlab/blob/7fc900168981e58051253ecc66a18015a052cd2f/packages/theme-light-extension/webpack.config.js) before [jupyterlab/jupyterlab/#5505](https://github.com/jupyterlab/jupyterlab/pull/5505).