### PR TITLE
Improve the CI test

### DIFF
--- a/ci_script.sh
+++ b/ci_script.sh
@@ -6,8 +6,25 @@
 set -ex
 set -o pipefail
 
-# Make sure we can create, install, and run the default theme extension created by the cookiecutter
+JL_SETTINGS=./.jupyter/lab/user-settings
+THEME_SETTINGS=${JL_SET_DIR}/@jupyterlab/apputils-extension/themes.jupyterlab-settings
+
+# Create a theme extension using the cookiecutter default inputs
 cookiecutter . --no-input
+
+# install theme
 jupyter labextension install ./mytheme
-python -m jupyterlab.browser_check
+
+# enable the theme in user-settings
+mkdir -p $(dirname $THEME_SET)
+cat > THEME_SETTINGS << EOF
+{
+    "theme": "mytheme"
+}
+EOF
+
+# print out a confirmation that the extension is installed
 jupyter labextension list
+
+# run a test of the main JupyterLab app with the theme enabled
+JUPYTERLAB_SETTINGS_DIR=$JL_SETTINGS python -m jupyterlab.browser_check

--- a/ci_script.sh
+++ b/ci_script.sh
@@ -7,7 +7,7 @@ set -ex
 set -o pipefail
 
 JL_SETTINGS=./.jupyter/lab/user-settings
-THEME_SETTINGS=${JL_SET_DIR}/@jupyterlab/apputils-extension/themes.jupyterlab-settings
+THEME_SETTINGS=${JL_SETTINGS}/@jupyterlab/apputils-extension/themes.jupyterlab-settings
 
 # Create a theme extension using the cookiecutter default inputs
 cookiecutter . --no-input
@@ -16,7 +16,7 @@ cookiecutter . --no-input
 jupyter labextension install ./mytheme
 
 # enable the theme in user-settings
-mkdir -p $(dirname $THEME_SET)
+mkdir -p $(dirname $THEME_SETTINGS)
 cat > THEME_SETTINGS << EOF
 {
     "theme": "mytheme"

--- a/ci_script.sh
+++ b/ci_script.sh
@@ -7,8 +7,8 @@ set -ex
 set -o pipefail
 
 # set a custom user-settings directory
-export JUPYTERLAB_SETTINGS_DIR=./.jupyter/lab/user-settings
-THEME_SETTINGS=${JUPYTERLAB_SETTINGS_DIR}/@jupyterlab/apputils-extension/themes.jupyterlab-settings
+export JUPYTERLAB_SETTINGS_DIR="./.jupyter/lab/user-settings"
+THEME_SETTINGS="${JUPYTERLAB_SETTINGS_DIR}/@jupyterlab/apputils-extension/themes.jupyterlab-settings"
 
 # Create a theme extension using the cookiecutter default inputs
 cookiecutter . --no-input
@@ -18,11 +18,7 @@ jupyter labextension install ./mytheme
 
 # enable the theme in user-settings
 mkdir -p $(dirname $THEME_SETTINGS)
-cat > THEME_SETTINGS << EOF
-{
-    "theme": "mytheme"
-}
-EOF
+printf "%s\n" "{" "    \"theme\": \"mytheme\"" "}" > $THEME_SETTINGS
 
 # print out a confirmation that the extension is installed
 jupyter labextension list

--- a/ci_script.sh
+++ b/ci_script.sh
@@ -6,8 +6,9 @@
 set -ex
 set -o pipefail
 
-JL_SETTINGS=./.jupyter/lab/user-settings
-THEME_SETTINGS=${JL_SETTINGS}/@jupyterlab/apputils-extension/themes.jupyterlab-settings
+# set a custom user-settings directory
+export JUPYTERLAB_SETTINGS_DIR=./.jupyter/lab/user-settings
+THEME_SETTINGS=${JUPYTERLAB_SETTINGS_DIR}/@jupyterlab/apputils-extension/themes.jupyterlab-settings
 
 # Create a theme extension using the cookiecutter default inputs
 cookiecutter . --no-input
@@ -27,4 +28,4 @@ EOF
 jupyter labextension list
 
 # run a test of the main JupyterLab app with the theme enabled
-JUPYTERLAB_SETTINGS_DIR=$JL_SETTINGS python -m jupyterlab.browser_check
+python -m jupyterlab.browser_check


### PR DESCRIPTION
The CI test will now run JupyterLab with the new theme actually enabled. This will require the small tweak to `.css` url mangling in the PR jupyterlab/jupyterlab_server#62 in order to be functional.