### PR TITLE
Remote the style key from `package.json`

### DIFF
--- a/{{cookiecutter.python_name}}/package.json
+++ b/{{cookiecutter.python_name}}/package.json
@@ -19,7 +19,6 @@
   ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "style": "style/index.css",
   "repository": {
     "type": "git",
     "url": "{{ cookiecutter.repository }}.git"


### PR DESCRIPTION
As noticed in https://github.com/telamonian/theme-darcula/issues/32, discussed in https://github.com/jupyterlab/jupyterlab/pull/10381 and https://github.com/jupyterlab/jupyterlab/issues/10378.

Similar to https://github.com/telamonian/theme-darcula/pull/33