### PR TITLE
Add Lab PyPI trove classifiers

### DIFF
--- a/{{cookiecutter.python_name}}/setup.py
+++ b/{{cookiecutter.python_name}}/setup.py
@@ -87,6 +87,10 @@ setup_args = dict(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Framework :: Jupyter",
+        "Framework :: Jupyter :: JupyterLab :: 3",
+        "Framework :: Jupyter :: JupyterLab :: Extensions",
+        "Framework :: Jupyter :: JupyterLab :: Extensions :: Prebuilt",
+        "Framework :: Jupyter :: JupyterLab :: Extensions :: Themes",
     ],
 )
 


### PR DESCRIPTION
## References

- follow-on to https://github.com/jupyterlab/jupyterlab/pull/10731

## Changes

- adds formally accepted (but not-yet-on-PyPI) trove classifiers

