### PR TITLE
Add --jp-statusbar-height to default variables.css

### DIFF
--- a/{{cookiecutter.python_name}}/style/variables.css
+++ b/{{cookiecutter.python_name}}/style/variables.css
@@ -315,6 +315,10 @@ all of MD as it is not optimized for dense, information rich UIs.
   --jp-toolbar-box-shadow: 0px 0px 2px 0px rgba(0, 0, 0, 0.24);
   --jp-toolbar-header-margin: 4px 4px 0px 4px;
   --jp-toolbar-active-background: var(--md-grey-300);
+  
+  /* Statusbar specific styles */
+
+  --jp-statusbar-height: 24px;
 
   /* Input field styles */
 


### PR DESCRIPTION
Keep up with jupyterlab/jupyterlab#10160, or JupyterLab 3.1

Without this line, status bar will be invisible.